### PR TITLE
Run "shellcheck" on PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -10,3 +10,5 @@ jobs:
     steps:
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@1.0.0
+        with:
+          severity: style

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,0 +1,12 @@
+---
+name: linting
+
+"on": push
+
+jobs:
+  shellcheck:
+    name: QA for Shellscripts
+    runs-on: ubuntu-latest
+    steps:
+      - name: ShellCheck
+        uses: ludeeus/action-shellcheck@1.0.0

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,5 +12,6 @@ jobs:
         uses: actions/checkout@v2
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@1.0.0
+        continue-on-error: true
         with:
           severity: style

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -8,6 +8,8 @@ jobs:
     name: QA for Shellscripts
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code from repository
+        uses: actions/checkout@v2
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@1.0.0
         with:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,3 +15,5 @@ jobs:
         continue-on-error: true
         with:
           severity: style
+          check_together: 'yes'
+          additional_files: 'samutev.conf.template'

--- a/samutev.sh
+++ b/samutev.sh
@@ -254,7 +254,7 @@ function delete_and_purge_VMs() {
     echo
     multipass delete "${VM}"
     duration=$SECONDS
-    echo "delaunched  $VM in $(($duration / 60)) minutes and $(($duration % 60)) seconds."
+    echo "delaunched  $VM in $((duration / 60)) minutes and $((duration % 60)) seconds."
     echo
   done
   multipass purge

--- a/samutev.sh
+++ b/samutev.sh
@@ -130,7 +130,7 @@ while (("$#")); do
       exit 1
     fi
     ;;
-  -* | --*=) # unsupported flags
+  --* | -*=) # unsupported flags
     echo "Error: Unsupported flag $1" >&2
     echo
     help


### PR DESCRIPTION
This adds a GitHub Action to execute [shellcheck](https://github.com/koalaman/shellcheck/) on the repository when filing pull requests.

As GitHub Actions [don't allow yet](https://github.com/actions/runner/issues/2347) to only act as a "warning", all errors will be ignored and won't block PRs for now, but the results of the executed Action will still be available for inspection within a PR.

Once all open issues are addressed at some point in the future, 358307b can be reverted to enforce a higher level of quality for further PRs.

This PR is intentionally set to **WIP** for now, as it is based on the branch to be merged in actions/toolkit#2. Once actions/toolkit#2 is merged, **WIP** can be removed from this PR.