### PR TITLE
Allow symlinking `samutev.sh`

### DIFF
--- a/samutev.sh
+++ b/samutev.sh
@@ -11,8 +11,10 @@ C_DEFAULT=2
 M_DEFAULT=1
 D_DEFAULT=3
 
+scriptpath=$(readlink -f "${0}")
+
 # shellcheck source=samutev.conf.template
-source "$(readlink -f "${0%.*}")".conf
+source "${scriptpath%.*}".conf
 
 if [ ! -d "$salt_base" ]; then
   echo


### PR DESCRIPTION
This fix allows symlinking samutev e.g. to `~/bin/samutev.sh`. Without thix fix, `samutev.sh` would try to find `samutev.conf` in `~/.bin/samutev.conf`