### PR TITLE
Trigger "linting" workflow on PRs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -1,7 +1,7 @@
 ---
 name: linting
 
-"on": push
+"on": [push, pull_request]
 
 jobs:
   shellcheck:


### PR DESCRIPTION
So far, GitHub action workflows were only triggered on pushes to a
repository.
This commit enables them for PRs as well.

See also:
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request